### PR TITLE
Fixed zombie caffeinate processes on OS X

### DIFF
--- a/lib/mac.js
+++ b/lib/mac.js
@@ -20,7 +20,7 @@ module.exports.prevent = function(cb) {
     }
 
     debug('Spawning caffeinate');
-    caffeine = child_process.spawn('caffeinate');
+    caffeine = child_process.spawn('caffeinate', ['-w ' + process.pid]);
     caffeine.on('error', function(err) {
         debug('Error in caffeinate. Computer can now sleep automatically.', err);
         callback(err, sleepCount);


### PR DESCRIPTION
The way this was implemented on OS X, if node crashed or `.allow()` didn't get called, `caffeinate` would keep running in the background even after the node process exited. I fixed this using the `-w` argument to `caffeinate`